### PR TITLE
DOO-522: Emit Event empty-jsonata-result

### DIFF
--- a/lib/actions/transform.js
+++ b/lib/actions/transform.js
@@ -44,7 +44,7 @@ async function processAction(msg, cfg, snapshots, msgHeaders, tokenData) {
           resultValue = 'empty object';
         }
         self.logger.info('Result from evaluation is empty object or null or undefined, no message will be send to the next step');
-        self.emit('empty-jsonata-result', { data: `Result from evaluation is ${resultValue}` });
+        self.emit('trace:empty-jsonata-result', { data: `Result from evaluation is ${resultValue}` });
         self.emit('end');
         return Promise.resolve();
       }
@@ -62,7 +62,7 @@ async function processAction(msg, cfg, snapshots, msgHeaders, tokenData) {
         self.logger.info(`${resultCount} messages were sent to the next step`);
         if (resultCount === 0) {
           self.logger.info('Result from evaluation is an empty iterable, no message will be sent to the next step');
-          self.emit('empty-jsonata-result', { data: 'Result from evaluation is an empty iterable, no message will be sent to the next step' });
+          self.emit('trace:empty-jsonata-result', { data: 'Result from evaluation is an empty iterable, no message will be sent to the next step' });
         }
         self.emit('end');
         return Promise.resolve();

--- a/lib/actions/transform.js
+++ b/lib/actions/transform.js
@@ -34,7 +34,17 @@ async function processAction(msg, cfg, snapshots, msgHeaders, tokenData) {
     return compiledExpression.evaluate(msg).then(async (result) => {
       self.logger.info('Evaluation completed');
       if (result === undefined || result === null || Object.keys(result).length === 0) {
+        // this may be userful for debugging
+        let resultValue = '';
+        if (result === null) {
+          resultValue = 'null';
+        } else if (result === undefined) {
+          resultValue = 'undefined';
+        } else {
+          resultValue = 'empty object';
+        }
         self.logger.info('Result from evaluation is empty object or null or undefined, no message will be send to the next step');
+        self.emit('empty-jsonata-result', { data: `Result from evaluation is ${resultValue}` });
         self.emit('end');
         return Promise.resolve();
       }
@@ -42,10 +52,17 @@ async function processAction(msg, cfg, snapshots, msgHeaders, tokenData) {
       if (typeof result[Symbol.iterator] === 'function') {
         // We have an iterator as result
         self.logger.debug('Result from evaluation is an array, each item of the array will be send to the next step as a separate message');
+        let resultCount = 0;
         // eslint-disable-next-line no-restricted-syntax
         for (const item of result) {
           // eslint-disable-next-line no-await-in-loop
           await self.emit('data', { data: item });
+          resultCount += 1;
+        }
+        self.logger.info(`${resultCount} messages were sent to the next step`);
+        if (resultCount === 0) {
+          self.logger.info('Result from evaluation is an empty iterable, no message will be sent to the next step');
+          self.emit('empty-jsonata-result', { data: 'Result from evaluation is an empty iterable, no message will be sent to the next step' });
         }
         self.emit('end');
         return Promise.resolve();

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@blendededge/ferryman-extensions": "^2.0.6",
+        "@blendededge/ferryman-extensions": "^2.1.0",
         "@openintegrationhub/ferryman": "^2.3.1",
         "country-code-lookup": "^0.1.0",
         "jsonata": "^2.0.3"
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@blendededge/ferryman-extensions": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@blendededge/ferryman-extensions/-/ferryman-extensions-2.0.6.tgz",
-      "integrity": "sha512-9ow3nGXV2ZVTY5pBKQFzOtlfTl4Mupto4XyPrm6O6ee2XQXNYF9vubRbmpTbBrw19WlZQAA/6y2cIPZBrPOY9Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@blendededge/ferryman-extensions/-/ferryman-extensions-2.1.0.tgz",
+      "integrity": "sha512-/ansus+f8KGmQSNwmfFpPUytVeSlIQTcwGjDm+2Ls9vXxtMDTBs0bPy7hVDNSrEcBZoSPVGCaEbkoJQR2lMT3g==",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/exporter-jaeger": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "@blendededge/ferryman-extensions": "^2.0.6",
+    "@blendededge/ferryman-extensions": "^2.1.0",
     "@openintegrationhub/ferryman": "^2.3.1",
     "country-code-lookup": "^0.1.0",
     "jsonata": "^2.0.3"


### PR DESCRIPTION
Under the following conditions the JSONata component does not emit data to a following step:
- an error occurs
- result is `null` or `undefined`
- result is an empty object `{}`
- result is an iterator with no items, e.g. an empty array `[]`

These will now trigger an event `trace:empty-jsonata-result`, with detail about the exact value of the result (whether it was `null`, `[]`, etc), and this event will be stored on the trace events array.

This also adds a log for when an empty iterator returns no items.